### PR TITLE
proxy docker tls option to twistcli

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ jobs:
 | `results_file` | File to which scan results are written in JSON | No | `pcc_scan_results.json` |
 | `sarif_file` | File to which scan results are written in SARIF | No | `pcc_scan_results.sarif.json` |
 | `docker_address` | Address of the Docker daemon (e.g. tcp://localhost:2375) | No |  |
+| `docker_tlscacert` | Path to Docker client CA certificate | No |  |
+| `docker_tlscert` | Path to Docker client Client certificate | No |  |
+| `docker_tlskey` | Path to Docker client Client private key | No |  |
 
 ### Outputs
 | Output | Description |

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,15 @@ inputs:
   docker_address:
     description: Address of the Docker daemon
     required: false
+  docker_tlscacert:
+    description: Path to Docker client CA certificate
+    required: false
+  docker_tlscert:
+    description: Path to Docker client Client certificate
+    required: false
+  docker_tlskey:
+    description: Path to Docker client Client private key
+    required: false
 outputs:
   results_file:
     description: File containing scan results

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 7351:
+/***/ 5350:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -15,7 +15,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const os = __importStar(__nccwpck_require__(2037));
-const utils_1 = __nccwpck_require__(5278);
+const utils_1 = __nccwpck_require__(7369);
 /**
  * Commands
  *
@@ -87,7 +87,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 2186:
+/***/ 6024:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -109,9 +109,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const command_1 = __nccwpck_require__(7351);
-const file_command_1 = __nccwpck_require__(717);
-const utils_1 = __nccwpck_require__(5278);
+const command_1 = __nccwpck_require__(5350);
+const file_command_1 = __nccwpck_require__(8466);
+const utils_1 = __nccwpck_require__(7369);
 const os = __importStar(__nccwpck_require__(2037));
 const path = __importStar(__nccwpck_require__(1017));
 /**
@@ -332,7 +332,7 @@ exports.getState = getState;
 
 /***/ }),
 
-/***/ 717:
+/***/ 8466:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -350,7 +350,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(7147));
 const os = __importStar(__nccwpck_require__(2037));
-const utils_1 = __nccwpck_require__(5278);
+const utils_1 = __nccwpck_require__(7369);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -368,7 +368,7 @@ exports.issueCommand = issueCommand;
 
 /***/ }),
 
-/***/ 5278:
+/***/ 7369:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -394,7 +394,7 @@ exports.toCommandValue = toCommandValue;
 
 /***/ }),
 
-/***/ 1514:
+/***/ 2423:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -416,7 +416,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tr = __importStar(__nccwpck_require__(8159));
+const tr = __importStar(__nccwpck_require__(9216));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -445,7 +445,7 @@ exports.exec = exec;
 
 /***/ }),
 
-/***/ 8159:
+/***/ 9216:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -471,8 +471,8 @@ const os = __importStar(__nccwpck_require__(2037));
 const events = __importStar(__nccwpck_require__(2361));
 const child = __importStar(__nccwpck_require__(2081));
 const path = __importStar(__nccwpck_require__(1017));
-const io = __importStar(__nccwpck_require__(7436));
-const ioUtil = __importStar(__nccwpck_require__(1962));
+const io = __importStar(__nccwpck_require__(6202));
+const ioUtil = __importStar(__nccwpck_require__(6120));
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
 /*
@@ -1052,7 +1052,7 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 9925:
+/***/ 9628:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1060,7 +1060,7 @@ class ExecState extends events.EventEmitter {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const http = __nccwpck_require__(3685);
 const https = __nccwpck_require__(5687);
-const pm = __nccwpck_require__(6443);
+const pm = __nccwpck_require__(6305);
 let tunnel;
 var HttpCodes;
 (function (HttpCodes) {
@@ -1479,7 +1479,7 @@ class HttpClient {
         if (useProxy) {
             // If using proxy, need tunnel
             if (!tunnel) {
-                tunnel = __nccwpck_require__(4294);
+                tunnel = __nccwpck_require__(9958);
             }
             const agentOptions = {
                 maxSockets: maxSockets,
@@ -1597,7 +1597,7 @@ exports.HttpClient = HttpClient;
 
 /***/ }),
 
-/***/ 6443:
+/***/ 6305:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1662,7 +1662,7 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 1962:
+/***/ 6120:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1871,7 +1871,7 @@ function isUnixExecutable(stats) {
 
 /***/ }),
 
-/***/ 7436:
+/***/ 6202:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1896,7 +1896,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const childProcess = __importStar(__nccwpck_require__(2081));
 const path = __importStar(__nccwpck_require__(1017));
 const util_1 = __nccwpck_require__(3837);
-const ioUtil = __importStar(__nccwpck_require__(1962));
+const ioUtil = __importStar(__nccwpck_require__(6120));
 const exec = util_1.promisify(childProcess.exec);
 /**
  * Copies a file or folder.
@@ -2190,7 +2190,7 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
-/***/ 2473:
+/***/ 378:
 /***/ (function(module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -2212,8 +2212,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const semver = __importStar(__nccwpck_require__(5911));
-const core_1 = __nccwpck_require__(2186);
+const semver = __importStar(__nccwpck_require__(1554));
+const core_1 = __nccwpck_require__(6024);
 // needs to be require for core node modules to be mocked
 /* eslint @typescript-eslint/no-require-imports: 0 */
 const os = __nccwpck_require__(2037);
@@ -2303,7 +2303,7 @@ exports._readLinuxVersionFile = _readLinuxVersionFile;
 
 /***/ }),
 
-/***/ 8279:
+/***/ 3704:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -2325,7 +2325,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__nccwpck_require__(2186));
+const core = __importStar(__nccwpck_require__(6024));
 /**
  * Internal class for retries
  */
@@ -2380,7 +2380,7 @@ exports.RetryHelper = RetryHelper;
 
 /***/ }),
 
-/***/ 7784:
+/***/ 3594:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -2405,20 +2405,20 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__nccwpck_require__(2186));
-const io = __importStar(__nccwpck_require__(7436));
+const core = __importStar(__nccwpck_require__(6024));
+const io = __importStar(__nccwpck_require__(6202));
 const fs = __importStar(__nccwpck_require__(7147));
-const mm = __importStar(__nccwpck_require__(2473));
+const mm = __importStar(__nccwpck_require__(378));
 const os = __importStar(__nccwpck_require__(2037));
 const path = __importStar(__nccwpck_require__(1017));
-const httpm = __importStar(__nccwpck_require__(9925));
-const semver = __importStar(__nccwpck_require__(5911));
+const httpm = __importStar(__nccwpck_require__(9628));
+const semver = __importStar(__nccwpck_require__(1554));
 const stream = __importStar(__nccwpck_require__(2781));
 const util = __importStar(__nccwpck_require__(3837));
-const v4_1 = __importDefault(__nccwpck_require__(824));
-const exec_1 = __nccwpck_require__(1514);
+const v4_1 = __importDefault(__nccwpck_require__(3902));
+const exec_1 = __nccwpck_require__(2423);
 const assert_1 = __nccwpck_require__(9491);
-const retry_helper_1 = __nccwpck_require__(8279);
+const retry_helper_1 = __nccwpck_require__(3704);
 class HTTPError extends Error {
     constructor(httpStatusCode) {
         super(`Unexpected HTTP response: ${httpStatusCode}`);
@@ -2993,34 +2993,34 @@ function _unique(values) {
 
 /***/ }),
 
-/***/ 6545:
+/***/ 992:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(2618);
+module.exports = __nccwpck_require__(6637);
 
 /***/ }),
 
-/***/ 8104:
+/***/ 6059:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
-var settle = __nccwpck_require__(3211);
-var buildFullPath = __nccwpck_require__(1934);
-var buildURL = __nccwpck_require__(646);
+var utils = __nccwpck_require__(6049);
+var settle = __nccwpck_require__(3578);
+var buildFullPath = __nccwpck_require__(6619);
+var buildURL = __nccwpck_require__(1218);
 var http = __nccwpck_require__(3685);
 var https = __nccwpck_require__(5687);
-var httpFollow = (__nccwpck_require__(7707).http);
-var httpsFollow = (__nccwpck_require__(7707).https);
+var httpFollow = (__nccwpck_require__(3854).http);
+var httpsFollow = (__nccwpck_require__(3854).https);
 var url = __nccwpck_require__(7310);
 var zlib = __nccwpck_require__(9796);
-var VERSION = (__nccwpck_require__(4322).version);
-var createError = __nccwpck_require__(5226);
-var enhanceError = __nccwpck_require__(1516);
-var defaults = __nccwpck_require__(8190);
-var Cancel = __nccwpck_require__(8875);
+var VERSION = (__nccwpck_require__(1657).version);
+var createError = __nccwpck_require__(6972);
+var enhanceError = __nccwpck_require__(5873);
+var defaults = __nccwpck_require__(7323);
+var Cancel = __nccwpck_require__(3417);
 
 var isHttps = /https:?/;
 
@@ -3371,22 +3371,22 @@ module.exports = function httpAdapter(config) {
 
 /***/ }),
 
-/***/ 3454:
+/***/ 1490:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
-var settle = __nccwpck_require__(3211);
-var cookies = __nccwpck_require__(1545);
-var buildURL = __nccwpck_require__(646);
-var buildFullPath = __nccwpck_require__(1934);
-var parseHeaders = __nccwpck_require__(6455);
-var isURLSameOrigin = __nccwpck_require__(3608);
-var createError = __nccwpck_require__(5226);
-var defaults = __nccwpck_require__(8190);
-var Cancel = __nccwpck_require__(8875);
+var utils = __nccwpck_require__(6049);
+var settle = __nccwpck_require__(3578);
+var cookies = __nccwpck_require__(5032);
+var buildURL = __nccwpck_require__(1218);
+var buildFullPath = __nccwpck_require__(6619);
+var parseHeaders = __nccwpck_require__(1758);
+var isURLSameOrigin = __nccwpck_require__(7364);
+var createError = __nccwpck_require__(6972);
+var defaults = __nccwpck_require__(7323);
+var Cancel = __nccwpck_require__(3417);
 
 module.exports = function xhrAdapter(config) {
   return new Promise(function dispatchXhrRequest(resolve, reject) {
@@ -3591,17 +3591,17 @@ module.exports = function xhrAdapter(config) {
 
 /***/ }),
 
-/***/ 2618:
+/***/ 6637:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
-var bind = __nccwpck_require__(7065);
-var Axios = __nccwpck_require__(8178);
-var mergeConfig = __nccwpck_require__(4831);
-var defaults = __nccwpck_require__(8190);
+var utils = __nccwpck_require__(6049);
+var bind = __nccwpck_require__(8743);
+var Axios = __nccwpck_require__(3274);
+var mergeConfig = __nccwpck_require__(6746);
+var defaults = __nccwpck_require__(7323);
 
 /**
  * Create an instance of Axios
@@ -3634,19 +3634,19 @@ var axios = createInstance(defaults);
 axios.Axios = Axios;
 
 // Expose Cancel & CancelToken
-axios.Cancel = __nccwpck_require__(8875);
-axios.CancelToken = __nccwpck_require__(1587);
-axios.isCancel = __nccwpck_require__(4057);
-axios.VERSION = (__nccwpck_require__(4322).version);
+axios.Cancel = __nccwpck_require__(3417);
+axios.CancelToken = __nccwpck_require__(3198);
+axios.isCancel = __nccwpck_require__(8458);
+axios.VERSION = (__nccwpck_require__(1657).version);
 
 // Expose all/spread
 axios.all = function all(promises) {
   return Promise.all(promises);
 };
-axios.spread = __nccwpck_require__(4850);
+axios.spread = __nccwpck_require__(6683);
 
 // Expose isAxiosError
-axios.isAxiosError = __nccwpck_require__(650);
+axios.isAxiosError = __nccwpck_require__(1185);
 
 module.exports = axios;
 
@@ -3656,7 +3656,7 @@ module.exports["default"] = axios;
 
 /***/ }),
 
-/***/ 8875:
+/***/ 3417:
 /***/ ((module) => {
 
 "use strict";
@@ -3683,13 +3683,13 @@ module.exports = Cancel;
 
 /***/ }),
 
-/***/ 1587:
+/***/ 3198:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Cancel = __nccwpck_require__(8875);
+var Cancel = __nccwpck_require__(3417);
 
 /**
  * A `CancelToken` is an object that can be used to request cancellation of an operation.
@@ -3810,7 +3810,7 @@ module.exports = CancelToken;
 
 /***/ }),
 
-/***/ 4057:
+/***/ 8458:
 /***/ ((module) => {
 
 "use strict";
@@ -3823,18 +3823,18 @@ module.exports = function isCancel(value) {
 
 /***/ }),
 
-/***/ 8178:
+/***/ 3274:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
-var buildURL = __nccwpck_require__(646);
-var InterceptorManager = __nccwpck_require__(3214);
-var dispatchRequest = __nccwpck_require__(5062);
-var mergeConfig = __nccwpck_require__(4831);
-var validator = __nccwpck_require__(1632);
+var utils = __nccwpck_require__(6049);
+var buildURL = __nccwpck_require__(1218);
+var InterceptorManager = __nccwpck_require__(4519);
+var dispatchRequest = __nccwpck_require__(6707);
+var mergeConfig = __nccwpck_require__(6746);
+var validator = __nccwpck_require__(5658);
 
 var validators = validator.validators;
 /**
@@ -3979,13 +3979,13 @@ module.exports = Axios;
 
 /***/ }),
 
-/***/ 3214:
+/***/ 4519:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(6049);
 
 function InterceptorManager() {
   this.handlers = [];
@@ -4041,14 +4041,14 @@ module.exports = InterceptorManager;
 
 /***/ }),
 
-/***/ 1934:
+/***/ 6619:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var isAbsoluteURL = __nccwpck_require__(1301);
-var combineURLs = __nccwpck_require__(7189);
+var isAbsoluteURL = __nccwpck_require__(788);
+var combineURLs = __nccwpck_require__(857);
 
 /**
  * Creates a new URL by combining the baseURL with the requestedURL,
@@ -4069,13 +4069,13 @@ module.exports = function buildFullPath(baseURL, requestedURL) {
 
 /***/ }),
 
-/***/ 5226:
+/***/ 6972:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var enhanceError = __nccwpck_require__(1516);
+var enhanceError = __nccwpck_require__(5873);
 
 /**
  * Create an Error with the specified message, config, error code, request and response.
@@ -4095,17 +4095,17 @@ module.exports = function createError(message, config, code, request, response) 
 
 /***/ }),
 
-/***/ 5062:
+/***/ 6707:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
-var transformData = __nccwpck_require__(9812);
-var isCancel = __nccwpck_require__(4057);
-var defaults = __nccwpck_require__(8190);
-var Cancel = __nccwpck_require__(8875);
+var utils = __nccwpck_require__(6049);
+var transformData = __nccwpck_require__(2659);
+var isCancel = __nccwpck_require__(8458);
+var defaults = __nccwpck_require__(7323);
+var Cancel = __nccwpck_require__(3417);
 
 /**
  * Throws a `Cancel` if cancellation has been requested.
@@ -4190,7 +4190,7 @@ module.exports = function dispatchRequest(config) {
 
 /***/ }),
 
-/***/ 1516:
+/***/ 5873:
 /***/ ((module) => {
 
 "use strict";
@@ -4241,13 +4241,13 @@ module.exports = function enhanceError(error, config, code, request, response) {
 
 /***/ }),
 
-/***/ 4831:
+/***/ 6746:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(6049);
 
 /**
  * Config-specific merge-function which creates a new config-object
@@ -4348,13 +4348,13 @@ module.exports = function mergeConfig(config1, config2) {
 
 /***/ }),
 
-/***/ 3211:
+/***/ 3578:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var createError = __nccwpck_require__(5226);
+var createError = __nccwpck_require__(6972);
 
 /**
  * Resolve or reject a Promise based on response status.
@@ -4381,14 +4381,14 @@ module.exports = function settle(resolve, reject, response) {
 
 /***/ }),
 
-/***/ 9812:
+/***/ 2659:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
-var defaults = __nccwpck_require__(8190);
+var utils = __nccwpck_require__(6049);
+var defaults = __nccwpck_require__(7323);
 
 /**
  * Transform the data for a request or a response
@@ -4411,15 +4411,15 @@ module.exports = function transformData(data, headers, fns) {
 
 /***/ }),
 
-/***/ 8190:
+/***/ 7323:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
-var normalizeHeaderName = __nccwpck_require__(6240);
-var enhanceError = __nccwpck_require__(1516);
+var utils = __nccwpck_require__(6049);
+var normalizeHeaderName = __nccwpck_require__(9478);
+var enhanceError = __nccwpck_require__(5873);
 
 var DEFAULT_CONTENT_TYPE = {
   'Content-Type': 'application/x-www-form-urlencoded'
@@ -4435,10 +4435,10 @@ function getDefaultAdapter() {
   var adapter;
   if (typeof XMLHttpRequest !== 'undefined') {
     // For browsers use XHR adapter
-    adapter = __nccwpck_require__(3454);
+    adapter = __nccwpck_require__(1490);
   } else if (typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]') {
     // For node use HTTP adapter
-    adapter = __nccwpck_require__(8104);
+    adapter = __nccwpck_require__(6059);
   }
   return adapter;
 }
@@ -4553,7 +4553,7 @@ module.exports = defaults;
 
 /***/ }),
 
-/***/ 4322:
+/***/ 1657:
 /***/ ((module) => {
 
 module.exports = {
@@ -4562,7 +4562,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7065:
+/***/ 8743:
 /***/ ((module) => {
 
 "use strict";
@@ -4581,13 +4581,13 @@ module.exports = function bind(fn, thisArg) {
 
 /***/ }),
 
-/***/ 646:
+/***/ 1218:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(6049);
 
 function encode(val) {
   return encodeURIComponent(val).
@@ -4659,7 +4659,7 @@ module.exports = function buildURL(url, params, paramsSerializer) {
 
 /***/ }),
 
-/***/ 7189:
+/***/ 857:
 /***/ ((module) => {
 
 "use strict";
@@ -4681,13 +4681,13 @@ module.exports = function combineURLs(baseURL, relativeURL) {
 
 /***/ }),
 
-/***/ 1545:
+/***/ 5032:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(6049);
 
 module.exports = (
   utils.isStandardBrowserEnv() ?
@@ -4742,7 +4742,7 @@ module.exports = (
 
 /***/ }),
 
-/***/ 1301:
+/***/ 788:
 /***/ ((module) => {
 
 "use strict";
@@ -4764,7 +4764,7 @@ module.exports = function isAbsoluteURL(url) {
 
 /***/ }),
 
-/***/ 650:
+/***/ 1185:
 /***/ ((module) => {
 
 "use strict";
@@ -4783,13 +4783,13 @@ module.exports = function isAxiosError(payload) {
 
 /***/ }),
 
-/***/ 3608:
+/***/ 7364:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(6049);
 
 module.exports = (
   utils.isStandardBrowserEnv() ?
@@ -4859,13 +4859,13 @@ module.exports = (
 
 /***/ }),
 
-/***/ 6240:
+/***/ 9478:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(6049);
 
 module.exports = function normalizeHeaderName(headers, normalizedName) {
   utils.forEach(headers, function processHeader(value, name) {
@@ -4879,13 +4879,13 @@ module.exports = function normalizeHeaderName(headers, normalizedName) {
 
 /***/ }),
 
-/***/ 6455:
+/***/ 1758:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(6049);
 
 // Headers whose duplicates are ignored by node
 // c.f. https://nodejs.org/api/http.html#http_message_headers
@@ -4940,7 +4940,7 @@ module.exports = function parseHeaders(headers) {
 
 /***/ }),
 
-/***/ 4850:
+/***/ 6683:
 /***/ ((module) => {
 
 "use strict";
@@ -4975,13 +4975,13 @@ module.exports = function spread(callback) {
 
 /***/ }),
 
-/***/ 1632:
+/***/ 5658:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var VERSION = (__nccwpck_require__(4322).version);
+var VERSION = (__nccwpck_require__(1657).version);
 
 var validators = {};
 
@@ -5065,13 +5065,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 328:
+/***/ 6049:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var bind = __nccwpck_require__(7065);
+var bind = __nccwpck_require__(8743);
 
 // utils is a library of generic helper functions non-specific to axios
 
@@ -5422,7 +5422,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8222:
+/***/ 8705:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /* eslint-env browser */
@@ -5679,7 +5679,7 @@ function localstorage() {
 	}
 }
 
-module.exports = __nccwpck_require__(6243)(exports);
+module.exports = __nccwpck_require__(8868)(exports);
 
 const {formatters} = module.exports;
 
@@ -5698,7 +5698,7 @@ formatters.j = function (v) {
 
 /***/ }),
 
-/***/ 6243:
+/***/ 8868:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -5714,7 +5714,7 @@ function setup(env) {
 	createDebug.disable = disable;
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
-	createDebug.humanize = __nccwpck_require__(900);
+	createDebug.humanize = __nccwpck_require__(1964);
 	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
@@ -5966,7 +5966,7 @@ module.exports = setup;
 
 /***/ }),
 
-/***/ 8237:
+/***/ 7763:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 /**
@@ -5975,15 +5975,15 @@ module.exports = setup;
  */
 
 if (typeof process === 'undefined' || process.type === 'renderer' || process.browser === true || process.__nwjs) {
-	module.exports = __nccwpck_require__(8222);
+	module.exports = __nccwpck_require__(8705);
 } else {
-	module.exports = __nccwpck_require__(5332);
+	module.exports = __nccwpck_require__(3468);
 }
 
 
 /***/ }),
 
-/***/ 5332:
+/***/ 3468:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /**
@@ -6017,7 +6017,7 @@ exports.colors = [6, 2, 3, 4, 5, 1];
 try {
 	// Optional dependency (as in, doesn't need to be installed, NOT like optionalDependencies in package.json)
 	// eslint-disable-next-line import/no-extraneous-dependencies
-	const supportsColor = __nccwpck_require__(9318);
+	const supportsColor = __nccwpck_require__(7819);
 
 	if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
 		exports.colors = [
@@ -6225,7 +6225,7 @@ function init(debug) {
 	}
 }
 
-module.exports = __nccwpck_require__(6243)(exports);
+module.exports = __nccwpck_require__(8868)(exports);
 
 const {formatters} = module.exports;
 
@@ -6253,7 +6253,7 @@ formatters.O = function (v) {
 
 /***/ }),
 
-/***/ 1133:
+/***/ 4496:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var debug;
@@ -6262,7 +6262,7 @@ module.exports = function () {
   if (!debug) {
     try {
       /* eslint global-require: off */
-      debug = __nccwpck_require__(8237)("follow-redirects");
+      debug = __nccwpck_require__(7763)("follow-redirects");
     }
     catch (error) { /* */ }
     if (typeof debug !== "function") {
@@ -6275,7 +6275,7 @@ module.exports = function () {
 
 /***/ }),
 
-/***/ 7707:
+/***/ 3854:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var url = __nccwpck_require__(7310);
@@ -6284,7 +6284,7 @@ var http = __nccwpck_require__(3685);
 var https = __nccwpck_require__(5687);
 var Writable = (__nccwpck_require__(2781).Writable);
 var assert = __nccwpck_require__(9491);
-var debug = __nccwpck_require__(1133);
+var debug = __nccwpck_require__(4496);
 
 // Create handlers that pass events from native requests
 var events = ["abort", "aborted", "connect", "error", "socket", "timeout"];
@@ -6851,7 +6851,7 @@ module.exports.wrap = wrap;
 
 /***/ }),
 
-/***/ 1621:
+/***/ 3303:
 /***/ ((module) => {
 
 "use strict";
@@ -6867,7 +6867,7 @@ module.exports = (flag, argv = process.argv) => {
 
 /***/ }),
 
-/***/ 900:
+/***/ 1964:
 /***/ ((module) => {
 
 /**
@@ -7036,7 +7036,7 @@ function plural(ms, msAbs, n, name) {
 
 /***/ }),
 
-/***/ 5911:
+/***/ 1554:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -8639,14 +8639,14 @@ function coerce (version, options) {
 
 /***/ }),
 
-/***/ 9318:
+/***/ 7819:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const os = __nccwpck_require__(2037);
 const tty = __nccwpck_require__(6224);
-const hasFlag = __nccwpck_require__(1621);
+const hasFlag = __nccwpck_require__(3303);
 
 const {env} = process;
 
@@ -8782,15 +8782,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4294:
+/***/ 9958:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(4219);
+module.exports = __nccwpck_require__(9306);
 
 
 /***/ }),
 
-/***/ 4219:
+/***/ 9306:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -9062,7 +9062,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 2707:
+/***/ 919:
 /***/ ((module) => {
 
 /**
@@ -9095,7 +9095,7 @@ module.exports = bytesToUuid;
 
 /***/ }),
 
-/***/ 5859:
+/***/ 7868:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Unique ID creation requires a high quality random # generator.  In node.js
@@ -9110,11 +9110,11 @@ module.exports = function nodeRNG() {
 
 /***/ }),
 
-/***/ 824:
+/***/ 3902:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var rng = __nccwpck_require__(5859);
-var bytesToUuid = __nccwpck_require__(2707);
+var rng = __nccwpck_require__(7868);
+var bytesToUuid = __nccwpck_require__(919);
 
 function v4(options, buf, offset) {
   var i = buf && offset || 0;
@@ -9316,10 +9316,10 @@ var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const fs = __nccwpck_require__(7147);
-const axios = (__nccwpck_require__(6545)["default"]);
-const core = __nccwpck_require__(2186);
-const { exec } = __nccwpck_require__(1514);
-const tc = __nccwpck_require__(7784);
+const axios = (__nccwpck_require__(992)["default"]);
+const core = __nccwpck_require__(6024);
+const { exec } = __nccwpck_require__(2423);
+const tc = __nccwpck_require__(3594);
 
 const TRUE_VALUES = ['true', 'yes', 'y', '1'];
 
@@ -9538,6 +9538,10 @@ async function scan() {
   const resultsFile = core.getInput('results_file');
   const sarifFile = core.getInput('sarif_file');
   const dockerAddress = core.getInput('docker_address') || process.env.DOCKER_ADDRESS;
+  const dockerTlscacert = core.getInput('docker_tlscacert')
+  const dockerTlscert = core.getInput('docker_tlscert')
+  const dockerTlskey = core.getInput('docker_tlskey')
+
   const httpProxy = process.env.https_proxy || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.HTTP_PROXY;
 
   try {
@@ -9572,6 +9576,15 @@ async function scan() {
     ]);
     if (dockerAddress) {
       twistcliCmd = twistcliCmd.concat([`--docker-address ${dockerAddress}`]);
+    }
+    if (dockerTlscacert != "") {
+      twistcliCmd = twistcliCmd.concat([`--docker-tlscacert ${dockerTlscacert}`]);
+    }
+    if (dockerTlscert != "") {
+      twistcliCmd = twistcliCmd.concat([`--docker-tlscert ${dockerTlscert}`]);
+    }
+    if (dockerTlskey != "") {
+      twistcliCmd = twistcliCmd.concat([`--docker-tlskey ${dockerTlskey}`]);
     }
     if (TRUE_VALUES.includes(containerized)) {
       twistcliCmd = twistcliCmd.concat(['--containerized']);

--- a/index.js
+++ b/index.js
@@ -221,6 +221,10 @@ async function scan() {
   const resultsFile = core.getInput('results_file');
   const sarifFile = core.getInput('sarif_file');
   const dockerAddress = core.getInput('docker_address') || process.env.DOCKER_ADDRESS;
+  const dockerTlscacert = core.getInput('docker_tlscacert')
+  const dockerTlscert = core.getInput('docker_tlscert')
+  const dockerTlskey = core.getInput('docker_tlskey')
+
   const httpProxy = process.env.https_proxy || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.HTTP_PROXY;
 
   try {
@@ -255,6 +259,15 @@ async function scan() {
     ]);
     if (dockerAddress) {
       twistcliCmd = twistcliCmd.concat([`--docker-address ${dockerAddress}`]);
+    }
+    if (dockerTlscacert != "") {
+      twistcliCmd = twistcliCmd.concat([`--docker-tlscacert ${dockerTlscacert}`]);
+    }
+    if (dockerTlscert != "") {
+      twistcliCmd = twistcliCmd.concat([`--docker-tlscert ${dockerTlscert}`]);
+    }
+    if (dockerTlskey != "") {
+      twistcliCmd = twistcliCmd.concat([`--docker-tlskey ${dockerTlskey}`]);
     }
     if (TRUE_VALUES.includes(containerized)) {
       twistcliCmd = twistcliCmd.concat(['--containerized']);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "axios": "^0.24.0"
   },
   "devDependencies": {
-    "eslint": "^7.23.0",
-    "@vercel/ncc": "^0.33.1"
+    "@vercel/ncc": "^0.33.1",
+    "eslint": "^7.23.0"
   }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
The recent addition of docker_address would only work on HTTP connections to Docker Hosts (port 2375) TLS connected clients and servers (port 2376) wouldn't work the action had no way to pass the docker-tls* options supported by the twistcli. 
This PR proxies those options from the Action to the CLI

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Build on Kubernetes with buildX using a different docker host with TLS

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
      - name: Prisma Cloud image scan
        id: prisma_scan
        uses: apr-1985/prisma-cloud-scan@docker-tls
        with:
          pcc_console_url: *** 
          pcc_user: ***
          pcc_pass: ${{ env.prisma_token }}
          image_name: ${{ inputs.image_name }}:lastest }}
          docker_address: tcp://localhost:2376
          docker_tlscacert: /certs/client/ca.pem
          docker_tlscert: /certs/client/cert.pem
          docker_tlskey: /certs/client/key.pem
```

results in

```
Run apr-1985/prisma-cloud-scan@docker-tls
  with:
    pcc_console_url: ***
    pcc_user: ***
    pcc_pass: ***
    image_name: java-demo-app:latest
    docker_address: tcp://localhost:2376
    docker_tlscacert: /certs/client/ca.pem
    docker_tlscert: /certs/client/cert.pem
    docker_tlskey: /certs/client/key.pem
    results_file: pcc_scan_results.json
    sarif_file: pcc_scan_results.sarif.json
  env:
    prisma_token: ***
/usr/bin/chmod a+x /runner/_work/_temp/2c324a16-61bb-4ef5-ae1f-17336fc9e889
/opt/hostedtoolcache/twistcli/20.12.535/x64/twistcli images scan --address *** --user *** -*** --output-file pcc_scan_results.json --details --docker-address tcp://localhost:2376 --docker-tlscacert /certs/client/ca.pem --docker-tlscert /certs/client/cert.pem --docker-tlskey /certs/client/key.pem java-demo-app:latest

Scan results for image java-demo-app:latest 


Vulnerabilities found for image java-demo-app:latest: total - 0, critical - 0, high - 0, medium - 0, low - 0
Vulnerability threshold check results: PASS
```

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->
Bug Fix.  This should have been in the original Docker Address addition 

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
