### PR TITLE
Alignment with Github Severity Levels

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14102,6 +14102,29 @@ function formatSarifToolDriverRules(results) {
   return [...vulns, ...comps];
 }
 
+/**
+ * convert prima severity to github severity
+ * @param {string} severity
+ * @throws {Error} unknown severity
+ * @returns string
+ */
+function convertPrismaSeverity(severity) {
+  // prisma: critical, high, medium, low
+  // gh: error, warning, note, none
+  switch (severity) {
+    case "critical":
+      return "error";
+    case "high":
+      return "warning";
+    case "medium":
+      return "note";
+    case "low":
+      return "none";
+    default:
+      throw new Error(`Unknown severity: ${severity}`);
+  }
+}
+
 function formatSarifResults(results) {
   // Only 1 image can be scanned at a time
   const result = results[0];
@@ -14118,7 +14141,7 @@ function formatSarifResults(results) {
     return findings.map(finding => {
       return {
         ruleId: `${finding.id}`,
-        level: 'warning',
+        level: `${convertPrismaSeverity(finding.severity)}`,
         message: {
           text: `Description:\n${finding.description}`,
         },

--- a/index.js
+++ b/index.js
@@ -148,6 +148,29 @@ function formatSarifToolDriverRules(results) {
   return [...vulns, ...comps];
 }
 
+/**
+ * convert prima severity to github severity
+ * @param {string} severity
+ * @throws {Error} unknown severity
+ * @returns string
+ */
+function convertPrismaSeverity(severity) {
+  // prisma: critical, high, medium, low
+  // gh: error, warning, note, none
+  switch (severity) {
+    case "critical":
+      return "error";
+    case "high":
+      return "warning";
+    case "medium":
+      return "note";
+    case "low":
+      return "none";
+    default:
+      throw new Error(`Unknown severity: ${severity}`);
+  }
+}
+
 function formatSarifResults(results) {
   // Only 1 image can be scanned at a time
   const result = results[0];
@@ -164,7 +187,7 @@ function formatSarifResults(results) {
     return findings.map(finding => {
       return {
         ruleId: `${finding.id}`,
-        level: 'warning',
+        level: `${convertPrismaSeverity(finding.severity)}`,
         message: {
           text: `Description:\n${finding.description}`,
         },


### PR DESCRIPTION
## Description

Align prisma severity levels with github advance security so they show up as expected in github.

Closes #8 

![image](https://github.com/PaloAltoNetworks/prisma-cloud-scan/assets/55592708/a4ba2b5c-581a-4ac4-bb48-76aca77eafb6)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
