### PR TITLE
Enhancing Sarif output with Security Severity Level

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14056,10 +14056,23 @@ function formatSarifToolDriverRules(results) {
   const result = results[0];
   const vulnerabilities = result.vulnerabilities;
   const compliances = result.compliances;
+   const severityLevel = {
+            "critical": "10.0",
+            "high": "8.9",
+            "medium": "6.9",
+            "low": "3.9",
+            "none": "0.0",
+  };
 
   let vulns = [];
   if (vulnerabilities) {
     vulns = vulnerabilities.map(vuln => {
+      let severtytocvss;
+      if (vuln.cvss !== undefined) {
+          severtytocvss = vuln.cvss.toString();
+      } else {
+          severtytocvss = severityLevel[vuln.severity.toString().toLowerCase()] || '0.0';
+      }
       return {
         id: `${vuln.id}`,
         shortDescription: {
@@ -14074,6 +14087,9 @@ function formatSarifToolDriverRules(results) {
             '| --- | --- | --- | --- | --- | --- | --- | --- |\n' +
             '| [' + vuln.id + '](' + vuln.link + ') | ' + vuln.severity + ' | ' + (vuln.cvss || 'N/A') + ' | ' + vuln.packageName + ' | ' + vuln.packageVersion + ' | ' + (vuln.status || 'not fixed') + ' | ' + vuln.publishedDate + ' | ' + vuln.discoveredDate + ' |',
         },
+	properties: {
+              'security-severity': severtytocvss,
+        },
       };
     });
   }
@@ -14081,6 +14097,9 @@ function formatSarifToolDriverRules(results) {
   let comps = [];
   if (compliances) {
     comps = compliances.map(comp => {
+      if (comp.severity) {
+            severtytocvss = severityLevel[comp.severity.toString().toLowerCase()] || '0.0';
+      }
       return {
         id: `${comp.id}`,
         shortDescription: {
@@ -14094,6 +14113,9 @@ function formatSarifToolDriverRules(results) {
           markdown: '| Compliance Check | Severity | Title |\n' +
             '| --- | --- | --- |\n' +
             '| ' + comp.id + ' | ' + comp.severity + ' | ' + comp.title + ' |',
+        },
+	 properties: {
+              'security-severity': severtytocvss,
         },
       };
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -14142,6 +14142,8 @@ function convertPrismaSeverity(severity) {
       return "note";
     case "low":
       return "none";
+    case "negligible":
+      return "none";
     default:
       throw new Error(`Unknown severity: ${severity}`);
   }


### PR DESCRIPTION
## Description

Enhancing Rule Name and Short Description with Severity Level for Sarif output.

This pull request introduces an enhancement to the  formatSarifToolDriverRules and convertPrismaSeverity functions.

The main changes include:

Addition of security-severity property: This property, which is only included if record.severity exists, maps the severity level of a record to a specific score, providing a quantifiable measure of the severity. The mapping is as follows:
{
    "critical": "10.0",
    "high": "8.9",
    "medium": "6.9",
    "low": "3.9",
    "none": "0.0",
}
This update aims to provide more detailed and descriptive information about the severity of a vulnerability or issue at a glance, aiding users in prioritizing and addressing these issues effectively.

I added severity negligible  in convertPrismaSeverity function

case "negligible":
      return "none";

## Motivation and Context

Scan report was reporting confusing information between the severity in Prisma Cloud and SARIF output.

## Screenshots
Scan report before the changes:

![image (1)](https://github.com/PaloAltoNetworks/prisma-cloud-scan/assets/120560665/ef77e01c-a9cf-421b-8e33-4e4237f0bd1a)

Scan report after applying the changes:

![image (7)](https://github.com/PaloAltoNetworks/prisma-cloud-scan/assets/120560665/66a4c8bd-6979-4bc0-abdf-d4c41085e732)


## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes if appropriate.
- [ x] All new and existing tests passed.
