### PR TITLE
Enhance SARIF output with Security Severity Level

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14056,10 +14056,24 @@ function formatSarifToolDriverRules(results) {
   const result = results[0];
   const vulnerabilities = result.vulnerabilities;
   const compliances = result.compliances;
+  const severityLevel = {
+            "critical": "10.0",
+            "high": "8.9",
+	    "important": "8.9",
+	    "moderate": "6.9",
+            "medium": "6.9",
+            "low": "3.9",
+	    "negligible": "3.9",
+            "none": "0.0",
+  };
 
   let vulns = [];
   if (vulnerabilities) {
     vulns = vulnerabilities.map(vuln => {
+      let severtytocvss;
+      if (vuln.severity) {
+            severtytocvss = severityLevel[vuln.severity.toString().toLowerCase()] || '0.0';
+      }
       return {
         id: `${vuln.id}`,
         shortDescription: {
@@ -14074,6 +14088,9 @@ function formatSarifToolDriverRules(results) {
             '| --- | --- | --- | --- | --- | --- | --- | --- |\n' +
             '| [' + vuln.id + '](' + vuln.link + ') | ' + vuln.severity + ' | ' + (vuln.cvss || 'N/A') + ' | ' + vuln.packageName + ' | ' + vuln.packageVersion + ' | ' + (vuln.status || 'not fixed') + ' | ' + vuln.publishedDate + ' | ' + vuln.discoveredDate + ' |',
         },
+	properties: {
+              'security-severity': severtytocvss,
+        },
       };
     });
   }
@@ -14081,6 +14098,9 @@ function formatSarifToolDriverRules(results) {
   let comps = [];
   if (compliances) {
     comps = compliances.map(comp => {
+      if (comp.severity) {
+            severtytocvss = severityLevel[comp.severity.toString().toLowerCase()] || '0.0';
+      }
       return {
         id: `${comp.id}`,
         shortDescription: {
@@ -14094,6 +14114,9 @@ function formatSarifToolDriverRules(results) {
           markdown: '| Compliance Check | Severity | Title |\n' +
             '| --- | --- | --- |\n' +
             '| ' + comp.id + ' | ' + comp.severity + ' | ' + comp.title + ' |',
+        },
+	properties: {
+              'security-severity': severtytocvss,
         },
       };
     });
@@ -14115,10 +14138,13 @@ function convertPrismaSeverity(severity) {
     case "critical":
       return "error";
     case "high":
+    case "important":
       return "warning";
     case "medium":
+    case "moderate":
       return "note";
     case "low":
+    case "negligible":
       return "none";
     default:
       throw new Error(`Unknown severity: ${severity}`);


### PR DESCRIPTION
Description
Enhancing Rule Name and Short Description with Severity Level for Sarif output.

This pull request introduces an enhancement to the formatSarifToolDriverRules and convertPrismaSeverity functions.

The main changes include:

Addition of security-severity property: This property, which is only included if record.severity exists, maps the severity level of a record to a specific score, providing a quantifiable measure of the severity. The mapping is as follows:
{
            "critical": "10.0",
            "high": "8.9",
	    "important": "8.9",
	    "moderate": "6.9",
            "medium": "6.9",
            "low": "3.9",
	    "negligible": "3.9",
            "none": "0.0",
}
This update aims to provide more detailed and descriptive information about the severity of a vulnerability or issue at a glance, aiding users in prioritizing and addressing these issues effectively.

I added severity negligible in convertPrismaSeverity function
 case "important":
      return "warning";
 case "moderate":
      return "note";
 case "negligible":
     return "none";

Motivation and Context
Scan report was reporting confusing information between the severity in Prisma Cloud and SARIF output.

Screenshots
Scan report before the changes:

![254632824-ef77e01c-a9cf-421b-8e33-4e4237f0bd1a](https://github.com/PaloAltoNetworks/prisma-cloud-scan/assets/120560665/a95460ba-05d5-4744-92c8-c940a3408898)


Scan report after applying the changes:

<img width="1991" alt="Screenshot 2023-07-24 at 13 37 49" src="https://github.com/PaloAltoNetworks/prisma-cloud-scan/assets/120560665/77ff939e-022e-4ddc-8d58-2f3885df99e4">


Types of changes
Bug fix (non-breaking change which fixes an issue)

Checklist
[ x] I have updated the documentation accordingly.
[ x] I have read the CONTRIBUTING document.
[ x] I have added tests to cover my changes if appropriate.
[ x] All new and existing tests passed.