### PR TITLE
Remove the duplicate CVE as a fix for the invalid SARIF files. 

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14702,7 +14702,9 @@ async function scan() {
       core.setFailed('Image scan failed');
     }
 
-    const resultsFileFiltered = resultsFile.results.filter(
+    vulnResults = resultsFile.results
+
+    const resultsFileFiltered = vulnResults.filter(
       (thing, index, self) =>
         index ===
         self.findIndex((t) => t.id === thing.id )

--- a/dist/index.js
+++ b/dist/index.js
@@ -14702,8 +14702,8 @@ async function scan() {
       core.setFailed('Image scan failed');
     }
 
-    const resultsFileFiltered = arr.filter(
-      (resultsFile, index, self) =>
+    const resultsFileFiltered = resultsFile.filter(
+      (thing, index, self) =>
         index ===
         self.findIndex((t) => t.id === thing.id )
     ); 

--- a/dist/index.js
+++ b/dist/index.js
@@ -14490,9 +14490,16 @@ function formatSarifToolDriverRules(results) {
   const vulnerabilities = result.vulnerabilities;
   const compliances = result.compliances;
 
+  const vulnerabilitiesFiltered = vulnerabilities.filter(
+    (thing, index, self) =>
+      index ===
+      self.findIndex((t) => t.id === thing.id )
+  ); 
+
+
   let vulns = [];
-  if (vulnerabilities) {
-    vulns = vulnerabilities.map(vuln => {
+  if (vulnerabilitiesFiltered) {
+    vulns = vulnerabilitiesFiltered.map(vuln => {
       return {
         id: `${vuln.id}`,
         shortDescription: {
@@ -14702,17 +14709,9 @@ async function scan() {
       core.setFailed('Image scan failed');
     }
 
-    vulnResults = resultsFile.results
+    fs.writeFileSync(sarifFile, JSON.stringify(formatSarif(twistcliVersion, resultsFile)));
 
-    const resultsFileFiltered = vulnResults.filter(
-      (thing, index, self) =>
-        index ===
-        self.findIndex((t) => t.id === thing.id )
-    ); 
-
-    fs.writeFileSync(sarifFile, JSON.stringify(formatSarif(twistcliVersion, resultsFileFiltered)));
-
-    core.setOutput('results_file', resultsFileFiltered);
+    core.setOutput('results_file', resultsFile);
     core.setOutput('sarif_file', sarifFile);
   } catch (err) {
     core.setFailed(`Image scan failed: ${err.message}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -14702,7 +14702,7 @@ async function scan() {
       core.setFailed('Image scan failed');
     }
 
-    const resultsFileFiltered = resultsFile.filter(
+    const resultsFileFiltered = resultsFile.results.filter(
       (thing, index, self) =>
         index ===
         self.findIndex((t) => t.id === thing.id )

--- a/dist/index.js
+++ b/dist/index.js
@@ -14702,9 +14702,15 @@ async function scan() {
       core.setFailed('Image scan failed');
     }
 
-    fs.writeFileSync(sarifFile, JSON.stringify(formatSarif(twistcliVersion, resultsFile)));
+    const resultsFileFiltered = arr.filter(
+      (resultsFile, index, self) =>
+        index ===
+        self.findIndex((t) => t.id === thing.id )
+    ); 
 
-    core.setOutput('results_file', resultsFile);
+    fs.writeFileSync(sarifFile, JSON.stringify(formatSarif(twistcliVersion, resultsFileFiltered)));
+
+    core.setOutput('results_file', resultsFileFiltered);
     core.setOutput('sarif_file', sarifFile);
   } catch (err) {
     core.setFailed(`Image scan failed: ${err.message}`);


### PR DESCRIPTION
## Description

Remove the duplicate CVE as a fix for the invalid SARIF files. 

## Motivation and Context

See issue #26 

## How Has This Been Tested?

Yes with image `alperthod/dotnet:latest` which contains duplicate CVEs 



## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
