### PR TITLE
Fix vulnerability duplicate filtering

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14490,7 +14490,7 @@ function formatSarifToolDriverRules(results) {
   const vulnerabilities = result.vulnerabilities;
   const compliances = result.compliances;
 
-  const vulnerabilitiesFiltered = vulnerabilities.filter(
+  const vulnerabilitiesFiltered = (vulnerabilities || []).filter(
     (thing, index, self) =>
       index ===
       self.findIndex((t) => t.id === thing.id )


### PR DESCRIPTION
## Description

On the latest release (v1.6.2) of the Action, SARIF uploads fail when a container has zero vulnerabilities. The error is:

`Failed formatting SARIF: Cannot read properties of undefined (reading 'filter')`

The change in this PR ensures that the vulnerabilities variable is always defined, so that this error does not occur.

## How Has This Been Tested?

Tested this locally against images with and without vulnerabilities.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
