### PR TITLE
Avoid usage of always() in README as a bad practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
 
       # (Optional) for compatibility with GitHub's code scanning alerts
       - name: Upload SARIF file
-        if: ${{ always() }} # necessary if using failure thresholds in the image scan
+        if: ${{ !cancelled() }} # necessary if using failure thresholds in the image scan
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{ steps.scan.outputs.sarif_file }}


### PR DESCRIPTION
## Description

Update docs with best practice.

From https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#always
> Avoid using always for any task that could suffer from a critical failure, for example: getting sources, otherwise the workflow may hang until it times out. If you want to run a job or step regardless of its success or failure, use the recommended alternative: if: ${{ !cancelled() }}

## Motivation and Context
Best practice

## How Has This Been Tested?
n/a
## Screenshots (if appropriate)
n/a
## Types of changes


- Bug fix (non-breaking change which fixes an issue)
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
