### PR TITLE
Support for node version 24

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,4 +57,4 @@ npm run lint    # ESLint on index.js
 npm run build   # Compile index.js → dist/index.js
 ```
 
-Node.js 20 is required (matches the action runtime).
+Node.js 24 is required (matches the action runtime).

--- a/action.yml
+++ b/action.yml
@@ -59,5 +59,5 @@ outputs:
   sarif_file:
     description: File containing scan results in SARIF
 runs:
-  using: node20
+  using: node24
   main: dist/index.js


### PR DESCRIPTION
## Description

Changed from using node verison 20 to version 24, to be able to support needed migration for GitHub execution after June 2026.

## Motivation and Context

Why?
GitHub runners requires node veriosno 24 from June 2026:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Fixes issue #75 
https://github.com/PaloAltoNetworks/prisma-cloud-scan/issues/75

## How Has This Been Tested?

Have ran the required commands locally.

## Screenshots (if appropriate)

N/A

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
